### PR TITLE
Fix casing in Custom attributes in TOC

### DIFF
--- a/en/manual/toc.md
+++ b/en/manual/toc.md
@@ -31,7 +31,7 @@
 ## [Procedural animation](animation/procedural-animation.md)
 ## [Custom blend trees](animation/custom-blend-trees.md)
 ## [Model node links](animation/model-node-links.md)
-## [custom attributes](animation/custom-attributes.md)
+## [Custom attributes](animation/custom-attributes.md)
 
 # [Audio](audio/index.md)
 ## [Import audio](audio/import-audio.md)


### PR DESCRIPTION
Fix casing in 'Custom attributes' in TOC