### PR TITLE
Fix sprite doc

### DIFF
--- a/en/manual/sprites/edit-sprites.md
+++ b/en/manual/sprites/edit-sprites.md
@@ -110,16 +110,16 @@ You can set the properties of individual sprites in the **Property Grid**.
 
 ![Adjust frame properties](media/adjust-frame-properties.png)
 
-| Property | Description
-|--------------------|-------------------------
-| Source | The path to the sprite sheet
-| Name | The name of this sprite. You can also edit this by double-clicking a sprite in the sprite list in the Sprite Editor
-| Texture region | The region of the sprite sheet used for this sprite
-| Pixels per unit | The number of pixels representing a unit in the scene. The higher this number, the smaller the sprite is rendered in the scene
-| Orientation | If you select **Rotated90**, Stride rotates the sprite 90 degrees at runtime
-| Center | The position of the center of the sprite, in pixels. By default, the center is **0, 0**. Note: this property is only available if the sprite sheet type is set to **Sprite2D** in the Sprite Editor.
-| Center from middle | Have the value in the Center property represent the offset of the sprite center from the middle of the sprite. Note: this property is only available if the sprite sheet type is set to **Sprite2D** in the Sprite Editor.
-| Borders |  The size in pixels of the sprite borders (areas that don't deform when stretched). X is the left border, Y is the top, Z is the right, and W is the bottom. For more information, see [Set sprite borders](set-sprite-borders.md). Note: this property is only available if the sprite sheet is set to **UI** on the left.
+| Property | Description |
+|--------------------|------------------------- |
+| Source | The path to the sprite sheet |
+| Name | The name of this sprite. You can also edit this by double-clicking a sprite in the sprite list in the Sprite Editor |
+| Texture region | The region of the sprite sheet used for this sprite |
+| Pixels per unit | The number of pixels representing a unit in the scene. The higher this number, the smaller the sprite is rendered in the scene |
+| Orientation | If you select **Rotated90**, Stride rotates the sprite 90 degrees at runtime |
+| Center | The position of the center of the sprite, in pixels. By default, the center is **0, 0**. Note: this property is only available if the sprite sheet type is set to **Sprite2D** in the Sprite Editor. |
+| Center from middle | Have the value in the Center property represent the offset of the sprite center from the middle of the sprite. Note: this property is only available if the sprite sheet type is set to **Sprite2D** in the Sprite Editor. |
+| Borders |  The size in pixels of the sprite borders (areas that don't deform when stretched). X is the left border, Y is the top, Z is the right, and W is the bottom. For more information, see [Set sprite borders](set-sprite-borders.md). Note: this property is only available if the sprite sheet is set to **UI** on the left. |
 
 ## Sprite sheet properties
 
@@ -134,25 +134,19 @@ Many of the properties are the same as texture properties.
 
 ![Sprite sheet properties](media/sprite-sheet-properties.png)
 
-| Property | Description 
-|--------------------|---------------
+| Property | Description |
+|--------------------|---------------|
 | Sheet Type | Specify whether this sprite sheet is used for 2D sprites or UI elements. If you select **Sprite sheet for UI**, you can define [sprite borders](set-sprite-borders.md) in the sprites.|
-| Color Key Color | The color used for transparency at runtime. This is only applied if **Color Key Enabled** is selected below
-| Color Key Enabled | Use the color set in the **Color Key Color** property for transparency at runtime. If this isn't selected, the project uses transparent areas of the sprite sheet instead
-| Format | The texture format all sprites in the sprite sheet are compressed to (compressed, 32-bit, 16-bit, or as-is)
-| ColorSpace | The color space for the sprites in the sprite sheet (Auto, Linear, or Gamma)
-| Alpha | The texture alpha format which all the sprites in the sprite sheet are converted to (None, Mask, Explicit, Interpolated, or Auto) |
-| Sheet Type | Whether this sprite sheet is used for 2D sprites or UI elements. If you select **Sprite sheet for UI**, you can define [sprite borders](set-sprite-borders.md) in the sprites.|
-| Color Key Color | The color used for transparency at runtime. This is only applied if **Color Key Enabled** is selected below
-| Color Key Enabled | Use the color set in the **Color Key Color** property for transparency at runtime. If this isn't selected, the project uses transparent areas of the sprite sheet instead
-| Format | The texture format all sprites in the sprite sheet are compressed to (compressed, 32-bit, 16-bit, or as-is)
-| ColorSpace | The color space for the sprites in the sprite sheet (Auto, Linear, or Gamma)
+| Color Key Color | The color used for transparency at runtime. This is only applied if **Color Key Enabled** is selected below |
+| Color Key Enabled | Use the color set in the **Color Key Color** property for transparency at runtime. If this isn't selected, the project uses transparent areas of the sprite sheet instead |
+| Compress | Compress the texture to a format based on the target platform. The final texture size will be a multiple of 4. |
+| ColorSpace | The color space for the sprites in the sprite sheet (Auto, Linear, or Gamma) |
 | Alpha | The texture alpha format which all the sprites in the sprite sheet are converted to (None, Mask, Explicit, Interpolated, or Auto) |
 | Generate Mipmaps | Generates mipmaps for all sprites in the sprite sheet |
-| Premultiply Alpha |  Premultiply all color components of the images by their alpha component
-| Allow Multipacking | Generate multiple atlas textures if the sprites can't fit into a single atlas
-| Allow rotations | Rotate sprites inside the sprite sheet to optimize space. This doesn't affect how sprites are displayed at runtime.
-| Border size | The size in pixels of the border around the sprites. This prevents side effects in the sprite sheet.
+| Premultiply Alpha |  Premultiply all color components of the images by their alpha component |
+| Allow Multipacking | Generate multiple atlas textures if the sprites can't fit into a single atlas |
+| Allow rotations | Rotate sprites inside the sprite sheet to optimize space. This doesn't affect how sprites are displayed at runtime. |
+| Border size | The size in pixels of the border around the sprites. This prevents side effects in the sprite sheet. |
 
 ## See also
 

--- a/en/manual/sprites/media/adjust-sprite-border-from-property-grid.png
+++ b/en/manual/sprites/media/adjust-sprite-border-from-property-grid.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba6573586a60ce07ae1b91bc0c46412e16806455254cf87046a5b3c0d66ab56b
+size 19725

--- a/en/manual/sprites/media/sprite-sheet-properties.png
+++ b/en/manual/sprites/media/sprite-sheet-properties.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f69fc78b1b1b3c036054cf4f6f2dfa38fef42de694680954d6770d5e763f4ec9
-size 17158
+oid sha256:07662821bb9df40475a38e6d1658b388f8e594550c1739570465a6fc5dc4e7b3
+size 18178

--- a/en/manual/sprites/set-sprite-borders.md
+++ b/en/manual/sprites/set-sprite-borders.md
@@ -44,9 +44,15 @@
 >[!TIP]
 >You can zoom in and out using **Ctrl + mousewheel** to make precise selections.
 
+> [!TIP]
+>
+> For fine-tune control over the sprite borders, adjusting one-by-one in the **Property Grid**
+>
+> ![Adjust sprite borders from Property grid](media/adjust-sprite-border-from-property-grid.png)
+
 ## Lock the sprite borders
 
-By default, sprite borders move as you resize the texture region. To stop this happening, click **Lock the sprite borders** in the toolbar.
+By default, sprite borders move as you resize the texture region. To stop this from happening, click **Lock the sprite borders** in the toolbar.
 
 ![Lock icon](media/lock-icon.png)
 


### PR DESCRIPTION
- Remove duplicate property description and add a new one (with an update on a picture) that is not in a current version of the documentation
- Add tip for sprite borders' fine-tune control

I also found the option for the sprite component property that is not in the documentation but I'm pretty new to this game engine and still have no idea what it works so I don't add that one.