### PR TITLE
Clarify Transform Directions matrix

### DIFF
--- a/en/manual/stride-for-unity-developers/index.md
+++ b/en/manual/stride-for-unity-developers/index.md
@@ -155,6 +155,7 @@ In comparison to Unity, many of the Transform component's properties related to 
 
 #### Transform Directions
 Unlike Unity, Stride provides a Backward, Left, and Down property.
+Note that those are matrix properties, so setting one of those is not enough to properly rotate the matrix.
 
 | Unity®  | Stride |
 | ----- | ------- |


### PR DESCRIPTION
In unity setting Forward rotates the whole transform while here setting forward and not the rest of the matrix will skew the transform.