### PR TITLE
Corrected page title

### DIFF
--- a/en/manual/graphics/post-effects/fog.md
+++ b/en/manual/graphics/post-effects/fog.md
@@ -1,4 +1,4 @@
-# Bloom
+# Fog
 
 <span class="label label-doc-level">Beginner</span>
 <span class="label label-doc-audience">Artist</span>


### PR DESCRIPTION
It was said bloom instead of fog