### PR TITLE
Fixed error in Non-spatialized audio code example

### DIFF
--- a/en/manual/audio/non-spatialized-audio.md
+++ b/en/manual/audio/non-spatialized-audio.md
@@ -91,7 +91,7 @@ public class MySoundScript : SyncScript
     public override void Update()
     {
         // If music isn't playing but should be, play the music.
-        if (PlayMusic & musicInstance.PlayState != SoundPlayState.Playing)
+        if (PlayMusic & musicInstance.PlayState != PlayState.Playing)
         {
             musicInstance.Play();
         }

--- a/jp/manual/audio/non-spatialized-audio.md
+++ b/jp/manual/audio/non-spatialized-audio.md
@@ -90,7 +90,7 @@ public class MySoundScript : SyncScript
     public override void Update()
     {
         // 音楽が再生されていなくて、再生する必要がある場合は、音楽を再生する。
-        if (PlayMusic & musicInstance.PlayState != SoundPlayState.Playing)
+        if (PlayMusic & musicInstance.PlayState != PlayState.Playing)
         {
             musicInstance.Play();
         }


### PR DESCRIPTION
Fixed an error in the code example. The enum name was apparently changed at some point in the past.