### PR TITLE
Outline.md fixed with links

### DIFF
--- a/en/manual/graphics/post-effects/outline.md
+++ b/en/manual/graphics/post-effects/outline.md
@@ -1,4 +1,4 @@
-# Bloom
+# Outline
 
 <span class="label label-doc-level">Intermediate</span>
 <span class="label label-doc-audience">Artist</span>
@@ -22,10 +22,12 @@ Outline is applied before anti-aliasing.
 ## See also
 
 * [Anti-aliasing](anti-aliasing.md)
+* [Fog](fog.md)
 * [Outline](outline.md)
-* [Ambient occlusion](ambient-occlusion.md)
+* [Bloom](bloom.md)
 * [Bright filter](bright-filter.md)
 * [Color transforms](color-transforms/index.md)
 * [Depth of field](depth-of-field.md)
 * [Lens flare](lens-flare.md)
 * [Light streaks](light-streaks.md)
+* [Local reflections](local-reflections.md)


### PR DESCRIPTION
Changed titled name that correctly describes the outline effect and added themissing links in the "see also" category.