### PR TITLE
Actualized "Custom color transforms" page content (Xenko -> Stride)

### DIFF
--- a/en/manual/get-started/media/launch-your-game-IDE-icon.png
+++ b/en/manual/get-started/media/launch-your-game-IDE-icon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39460ab32e9a9f33d4c15cfe950abde8268783e321fdc1f123bf545af073ca54
-size 311
+oid sha256:acde48b9548dd79a20afcd10816eb978f26b8abe0510d1716895ca4034285ddd
+size 361

--- a/en/manual/graphics/post-effects/color-transforms/custom-color-transforms.md
+++ b/en/manual/graphics/post-effects/color-transforms/custom-color-transforms.md
@@ -14,7 +14,7 @@ To create a custom color transform, you need to write two files: an effect shade
 
 ## 1. Create a shader
 
-1. Make sure you have the [Stride Visual Studio extension](../../../get-started/visual-studio-extension.md) installed. This is necessary to convert the shader files from XSL ([Stride shading language](../../effects-and-shaders/index.md)) to `.cs` files.
+1. Make sure you have the [Stride Visual Studio extension](../../../get-started/visual-studio-extension.md) installed. This is necessary to convert the shader files from SDSL ([Stride shading language](../../effects-and-shaders/shading-language/index.md)) to `.cs` files.
 
 2. In Game Studio, in the toolbar, click ![Open in IDE](../../../get-started/media/launch-your-game-ide-icon.png) (**Open in IDE**) to open your project in Visual Studio.
 
@@ -30,13 +30,13 @@ To create a custom color transform, you need to write two files: an effect shade
 
     ![Create post effect](media/create-post-effect.png)
 
-    The Stride Visual Studio extension automatically generates a `.cs` file from the `.sdsl` file. The Solution Explorer lists it as a child of the `.xskl` file.
+    The Stride Visual Studio extension automatically generates a `.cs` file from the `.sdsl` file. The Solution Explorer lists it as a child of the `.sdsl` file.
 
     ![My post effect](media/my-post-effect.png)
 
 6. Open the `.sdsl` file, remove the existing lines, and write your shader.
 
-    Shaders are written in Stride Shading Language (XSL), which is based on HLSL. For more information, see [Shading language](index.md).
+    Shaders are written in Stride Shading Language (SDSL), which is based on HLSL. For more information, see [Shading language](../../effects-and-shaders/shading-language/index.md).
 
     For example, the shader below multiplies the image color by the `MyColor` parameter:
 
@@ -149,7 +149,7 @@ To create a custom color transform, you need to write two files: an effect shade
 
 ## See also
 
-* [Shading language](../../effects-and-shaders/index.md)
+* [Shading language](../../effects-and-shaders/shading-language/index.md)
 * [Custom shaders](../../effects-and-shaders/custom-shaders.md)
 * [Graphics compositor](../../graphics-compositor/index.md)
 * [Post effects](../index.md)

--- a/en/manual/graphics/post-effects/color-transforms/media/create-post-effect.png
+++ b/en/manual/graphics/post-effects/color-transforms/media/create-post-effect.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:05eab319a149bca4113cf02f7ad3a7fef6d068b64c15fee0ff0ca14f6a9f8c83
-size 33592
+oid sha256:94876c9eb61971821f317021128994f3373dee1a312242138f37cb941cf53136
+size 30415

--- a/en/manual/graphics/post-effects/color-transforms/media/my-post-effect.png
+++ b/en/manual/graphics/post-effects/color-transforms/media/my-post-effect.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:258321311220c4b4c07cf6775c74a6999a7cceea7dc53c848ec74098ae4519cd
-size 18207
+oid sha256:7cbb782664862f1e9f59315f9e34ff4fa83be6e457ce484969d9eea3c85061ef
+size 16826


### PR DESCRIPTION
Changes:

1. XSL -> SDSL (including screenshots)
2. Stride shading language links set exactly to the [Shading language](https://doc.stride3d.net/4.1/en/manual/graphics/effects-and-shaders/shading-language/index.html) page. 
Previously some were leading to [Effects and shaders](https://doc.stride3d.net/4.1/en/manual/graphics/effects-and-shaders/index.html) or [Color transforms](https://doc.stride3d.net/4.1/en/manual/graphics/post-effects/color-transforms/index.html) pages.
3. Updated "launch your game IDE" icon to a modern version.