### PR TITLE
Add documentation for userdoc custom property descriptions

### DIFF
--- a/en/manual/scripts/media/userdoc-example.png
+++ b/en/manual/scripts/media/userdoc-example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab3f46c8fc3b74c7c94c77a8cb7f27b7f7ba4888d49797a29222ad0389bbc308
+size 5949

--- a/en/manual/scripts/public-properties-and-fields.md
+++ b/en/manual/scripts/public-properties-and-fields.md
@@ -70,6 +70,36 @@ Game Studio no longer shows the property:
 
 ![Public property been hidden with ```[DataMemberIgnore]```](media/scripts-in-stride-public-property-with-datamemberignore.png)
 
+## Adding property descriptions
+
+When you add a `<userdoc>` comment block above your public property in code, Game Studio will display it in the description field.
+
+```cs
+	///<summary>
+	/// This summary won't show in Game Studio
+	///</summary>
+	///<userdoc>
+	/// This description will show in Game Studio
+	///</userdoc>
+	public float DelayTimeOut { get; set; }
+
+```
+
+Enable documentation file generation:
+```xml
+  <PropertyGroup>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+```
+
+> [!NOTE]
+> Game Studio will only look in your build output directory for each assembly. Using the above path is recommended.
+
+On next reload, the Game Studio should display the documentation:
+
+![The description now shows in the Property Grid](media/userdoc-example.png)
+
 ## See also
 
 * [Types of script](types-of-script.md)


### PR DESCRIPTION
The custom property documentation feature is now live in 4.1. This updates the docs to explain how to use it. 