### PR TITLE
fix: fixes #101 japanese manual

### DIFF
--- a/jp-build.ps1
+++ b/jp-build.ps1
@@ -36,7 +36,7 @@ Copy-Item jp/index.md jp_tmp -Force
 Copy-Item jp/manual -Recurse jp_tmp -Force
 Copy-Item en/docfx.json jp_tmp -Force
 (Get-Content jp_tmp/docfx.json) -replace "_site/en","_site/jp" | Set-Content jp_tmp/docfx.json
-deps\docfx\docfx.exe build jp_tmp\docfx.json
+deps\docfx\docfx.exe build jp_tmp\docfx.json --force
 Remove-Item jp_tmp -recurse 
 if ($LastExitCode -ne 0)
 {


### PR DESCRIPTION
This PR is just in case we need this.  

Added `--force` should use Japanese manual instead of cached EN manual.  

Fixes #101 