### PR TITLE
Just fixed a small spelling mistake in a code sample.

### DIFF
--- a/en/manual/ui/ui-libraries.md
+++ b/en/manual/ui/ui-libraries.md
@@ -50,7 +50,7 @@ public Button CreateButton()
     if (button != null)
     {        
         // attach a delegate to the Click event
-        someButton.Click += delegate
+        button.Click += delegate
         {
             // do something here...
         };

--- a/jp/manual/ui/ui-libraries.md
+++ b/jp/manual/ui/ui-libraries.md
@@ -100,7 +100,7 @@ public Button CreateButton()
     {        
         // Click イベントにデリゲートを登録します。
         // attach a delegate to the Click event
-        someButton.Click += delegate
+        button.Click += delegate
         {
             // ここで何かの作業をします。
             // do something here...


### PR DESCRIPTION
The variable 'someButton' never gets declared here. It's also just 'button' two pages further in the manual. 