### PR TITLE
Add library requirements tab for Fedora

### DIFF
--- a/en/manual/platforms/linux/setup-and-requirements.md
+++ b/en/manual/platforms/linux/setup-and-requirements.md
@@ -22,13 +22,13 @@ You need the following packages:
 
 To render fonts, we use the [FreeType](https://www.freetype.org/) library. The minimum required version is 2.6 and can be installed via:
 
-# [Ubuntu](#tab/freetype-ubuntu)
+### [Ubuntu](#tab/freetype-ubuntu)
 
 ```bash
 sudo apt-get install libfreetype6-dev
 ```
 
-# [Fedora](#tab/freetype-fedora)
+### [Fedora](#tab/freetype-fedora)
 
 ```bash
 sudo dnf install freetype-devel
@@ -40,13 +40,13 @@ sudo dnf install freetype-devel
 
 To play sounds and music, we use the [OpenAL](https://www.openal.org/) library. It can be installed via:
 
-# [Ubuntu](#tab/openal-ubuntu)
+### [Ubuntu](#tab/openal-ubuntu)
 
 ```bash
 sudo apt-get install libopenal-dev
 ```
 
-# [Fedora](#tab/openal-fedora)
+### [Fedora](#tab/openal-fedora)
 
 ```bash
 sudo dnf install openal-soft-devel
@@ -58,13 +58,13 @@ sudo dnf install openal-soft-devel
 
 To run games on Linux, we use the [SDL2](https://www.libsdl.org/) library which provides the ability to create windows, handle mouse, keyboard and joystick events. The minimum required version is 2.0.4 and can be installed via:
 
-# [Ubuntu](#tab/sdl2-ubuntu)
+### [Ubuntu](#tab/sdl2-ubuntu)
 
 ```bash
 sudo apt-get install libsdl2-dev
 ```
 
-# [Fedora](#tab/sdl2-fedora)
+### [Fedora](#tab/sdl2-fedora)
 
 ```bash
 sudo dnf install SDL2-devel

--- a/en/manual/platforms/linux/setup-and-requirements.md
+++ b/en/manual/platforms/linux/setup-and-requirements.md
@@ -22,25 +22,55 @@ You need the following packages:
 
 To render fonts, we use the [FreeType](https://www.freetype.org/) library. The minimum required version is 2.6 and can be installed via:
 
-```
+# [Ubuntu](#tab/freetype-ubuntu)
+
+```bash
 sudo apt-get install libfreetype6-dev
 ```
+
+# [Fedora](#tab/freetype-fedora)
+
+```bash
+sudo dnf install freetype-devel
+```
+
+---
 
 ## OpenAL
 
 To play sounds and music, we use the [OpenAL](https://www.openal.org/) library. It can be installed via:
 
-```
+# [Ubuntu](#tab/openal-ubuntu)
+
+```bash
 sudo apt-get install libopenal-dev
 ```
+
+# [Fedora](#tab/openal-fedora)
+
+```bash
+sudo dnf install openal-soft-devel
+```
+
+---
 
 ## SDL2
 
 To run games on Linux, we use the [SDL2](https://www.libsdl.org/) library which provides the ability to create windows, handle mouse, keyboard and joystick events. The minimum required version is 2.0.4 and can be installed via:
 
-```
+# [Ubuntu](#tab/sdl2-ubuntu)
+
+```bash
 sudo apt-get install libsdl2-dev
 ```
+
+# [Fedora](#tab/sdl2-fedora)
+
+```bash
+sudo dnf install SDL2-devel
+```
+
+---
 
 ### .NET Core
 

--- a/en/manual/platforms/linux/setup-and-requirements.md
+++ b/en/manual/platforms/linux/setup-and-requirements.md
@@ -72,9 +72,9 @@ sudo dnf install SDL2-devel
 
 ---
 
-### .NET Core
+## .NET Core
 
-For information about how to install .NET Core, see the [.NET Core instructions for Debian/Ubuntu](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x).
+For information about how to install .NET Core, see the [.NET Core instructions for Linux](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites).
 
 Make sure version 2.1.300+ and runtime 2.1+ is installed. To check which version you have installed, type:
 


### PR DESCRIPTION
As the title suggests, PR adds an additional tab with alternative commands for Fedora on the requirements page :)

![image](https://github.com/stride3d/stride-docs/assets/31008367/055eda66-9144-45e3-8037-2ae73d8a70a8)
