### PR TITLE
Warn about unsupported shading features

### DIFF
--- a/en/manual/graphics/effects-and-shaders/index.md
+++ b/en/manual/graphics/effects-and-shaders/index.md
@@ -30,8 +30,8 @@ Stride shaders are converted automatically to the target graphics platform — e
 
 For mobile platforms, shaders are optimized by a GLSL optimizer to improve performance.
 
->[!NOTE]
->converting to OpenGL Compute shaders are not supported in SDSL yet.
+> [!NOTE]
+> Converting to OpenGL Compute shaders are not supported in SDSL yet.
 
 ## In this section
 

--- a/en/manual/graphics/effects-and-shaders/index.md
+++ b/en/manual/graphics/effects-and-shaders/index.md
@@ -30,6 +30,9 @@ Stride shaders are converted automatically to the target graphics platform — e
 
 For mobile platforms, shaders are optimized by a GLSL optimizer to improve performance.
 
+>[!NOTE]
+>converting to OpenGL Compute shaders are not supported in SDSL yet.
+
 ## In this section
 
 * [Effect language](effect-language.md)


### PR DESCRIPTION
Johan and I were trying to compile the TR.Stride repo to OpenGL and Vulkan but this does not work due to the converter not supporting compute shaders in SDSL. 

This is a big blocker for Linux if anyone needs/uses compute shaders and would be frustrating to learn about late into development.

related to: https://github.com/johang88/TR.Stride/issues/6