### PR TITLE
Misc fixes

### DIFF
--- a/en/manual/engine/file-system.md
+++ b/en/manual/engine/file-system.md
@@ -19,11 +19,11 @@ var gamesave2 = VirtualFileSystem.ApplicationRoaming.OpenStream("gamesave001.dat
 
 ## Default mount points
 
-| Mount point | Description  | Writable | Cloud | Notes  | PC   | Android  | iOS   | Windows Phone 8.1   
-| ----------- | -------------| -------- | ----- | -------| ---- | -------- | ------- | --
-| data        | Application data, deployed by package    | ✗    | ✗     |           | Output directory/data    | APK itself  | Deployed package directory | InstalledLocation.Path
-| binary   | Application binaries, deployed by package | ✗  | ✗   | Usually the same as *app_data* (except on Android)  | Assembly directory | Assembly directory  | Assembly directory  | Assembly directory
-| roaming   | User specific data (roaming) | ✓    |  ✓    | Backup   | Output directory/roaming, *%APPDATA%* | *$(Context.getFilesDir)/roaming* | Library/roaming  | Roaming 
-| local  | User application data | ✓     |  ✓    | Backup   | Output directory/local | $(Context.getFilesDir)local    | Library/local  | Local 
-| cache   | Application cache   | ✓   | ✗    | DLC, etc. Might be deleted manually by user (restore, clear data, etc...)   | Output directory/cache, with do-not-back-up flags   | *$(Context.getFilesDir)/cache*   | Library/caches  | LocalCache  
-| tmp    | Application temporary data    | ✓        | ✗     | Might be deleted without notice by OS   | Output directory/temp, *%TEMP%/%APPNAME%*   | *$(Context.getCacheDir)*  | tmp | Temporary
+| Mount point | Description                               | Writable | Cloud | Notes                                                                     | PC                                                | Android                          | iOS                        |
+|-------------|-------------------------------------------|----------|-------|---------------------------------------------------------------------------|---------------------------------------------------|----------------------------------|----------------------------|
+| data        | Application data, deployed by package     | ✗        | ✗     |                                                                           | Output directory/data                             | APK itself                       | Deployed package directory |
+| binary      | Application binaries, deployed by package | ✗        | ✗     | Usually the same as *app_data* (except on Android)                        | Assembly directory                                | Assembly directory               | Assembly directory         |
+| roaming     | User specific data (roaming)              | ✓        | ✓     | Backup                                                                    | Output directory/roaming, *%APPDATA%*             | *$(Context.getFilesDir)/roaming* | Library/roaming            |
+| local       | User application data                     | ✓        | ✓     | Backup                                                                    | Output directory/local                            | $(Context.getFilesDir)local      | Library/local              |
+| cache       | Application cache                         | ✓        | ✗     | DLC, etc. Might be deleted manually by user (restore, clear data, etc...) | Output directory/cache, with do-not-back-up flags | *$(Context.getFilesDir)/cache*   | Library/caches             |
+| tmp         | Application temporary data                | ✓        | ✗     | Might be deleted without notice by OS                                     | Output directory/temp, *%TEMP%/%APPNAME%*         | *$(Context.getCacheDir)*         | tmp                        |

--- a/en/manual/files-and-folders/distribute-a-game.md
+++ b/en/manual/files-and-folders/distribute-a-game.md
@@ -65,7 +65,7 @@ After you create a release build, how you distribute it is up to you.
 
 To run games made with Stride on Windows, users need:
 
-* .NET 4.6.1
+* .NET 8 SDK
 
 * DirectX11 (included with Windows 10 and later), OpenGL, or Vulkan
 

--- a/en/manual/get-started/launch-stride.md
+++ b/en/manual/get-started/launch-stride.md
@@ -16,7 +16,7 @@ If you choose to install the latest version, the Stride Launcher asks if you wan
 
 ![Install Visual Studio integration](media/install-VS-plug-in-prompt.webp)
 
-The Stride Visual Studio extension adds syntax highlighting, live code validation, error checking, and navigation. It also lets you you [edit shaders directly from Visual Studio](../graphics/effects-and-shaders/custom-shaders.md). You don't need to install the extension to use Stride, but we recommend it, especially for programmers.
+The Stride Visual Studio extension lets you you [edit shaders directly from Visual Studio](../graphics/effects-and-shaders/custom-shaders.md). You don't need to install the extension to use Stride, but we recommend it, especially for programmers.
 
 ## Manage different versions of Stride
 

--- a/en/manual/get-started/visual-studio-extension.md
+++ b/en/manual/get-started/visual-studio-extension.md
@@ -2,7 +2,7 @@
 
 <span class="badge text-bg-primary">Beginner</span>
 
-The **Stride Visual Studio extension** adds syntax highlighting, live code validation, error checking, and navigation. It also lets you you [edit shaders directly from Visual Studio](../graphics/effects-and-shaders/custom-shaders.md).
+The **Stride Visual Studio extension** lets you [edit shaders directly from Visual Studio](../graphics/effects-and-shaders/custom-shaders.md).
 
 You don't need to install the extension to use Stride, but we recommend it, especially for programmers.
 

--- a/en/manual/nuget/create-packages.md
+++ b/en/manual/nuget/create-packages.md
@@ -5,9 +5,6 @@
 
 ## Open your project in Visual Studio
 
-> [!Note]
-> Game Studio will later support creating NuGet packages directly.
-
 First of all, after saving all your changes, open your project with Visual Studio. You can easily do this by clicking the appropriate button on the toolbar:
 
 ![Open project in Visual Studio](../game-studio/media/open-project-in-visual-studio.png)

--- a/en/manual/platforms/index.md
+++ b/en/manual/platforms/index.md
@@ -6,9 +6,9 @@ Stride is cross-platform game engine. This means you can create your game once, 
 
 ## Supported platforms
 
-* Windows Desktop 7, 8, 10
-* Windows Universal (UWP)
-* [Linux (Ubuntu)](linux/index.md)
+* Windows 7, 8, 10
+* Windows Universal Platform (UWP)
+* [Linux](linux/index.md)
 * Android 2.3 and later
 * [iOS 8.0 and later](ios.md)
 

--- a/en/manual/platforms/linux/setup-and-requirements.md
+++ b/en/manual/platforms/linux/setup-and-requirements.md
@@ -85,17 +85,29 @@ sudo dnf install SDL2-devel
 sudo pacman -S sdl2
 ```
 
----
+## FreeImage
 
-## .NET
+FreeImage is battle-tested library for loading and saving popular image file formats like BMP, PNG, JPEG etc. The minimum required version is 3.18 and can be installed via:
 
-For information about how to install .NET, see the [.NET instructions for Linux](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites).
 
-We recommend to install .NET 8. To check which version you have installed, type:
+### [Debian / Ubuntu](#tab/freeimage-ubuntu)
 
+```bash
+sudo apt install libfreeimage-dev
 ```
-dotnet --info
+
+### [Fedora](#tab/freeimage-fedora)
+
+```bash
+sudo dnf install freeimage-devel
 ```
+
+### [Arch](#tab/freeimage-arch)
+
+```bash
+sudo pacman -S freeimage
+```
+
 
 ## See also
 

--- a/en/manual/requirements/index.md
+++ b/en/manual/requirements/index.md
@@ -11,12 +11,14 @@ To develop projects with Stride, you need:
 | CPU | x64
 | GPU | Direct3D 10+ compatible GPU
 | RAM | 4GB (minimum), 8GB (recommended) <small class="text-secondary">[see (2)]</small>
+| .NET SDK | 8+ <small class="text-secondary">[see (3)]</small> |
 
 (1) Earlier versions of Windows _may_ work but are untested.
 
 (2) RAM requirements vary depending on your project:
 * Developing simple 2D applications doesn't require much RAM.
 * Developing 3D games with lots of assets requires larger amounts of RAM.
+(3) .NET SDK is being downloaded with the Stride installer
 
 
 ## Mobile development requirements 
@@ -25,10 +27,10 @@ To develop for mobile platforms, you also need:
 
 | Platform | Requirements
 |----------|-------
-| Android  | Xamarin <small class="text-secondary">[see (3)]</small>
-| iOS      | Mac computer, Xamarin <small class="text-secondary">[see (3)]</small>
+| Android  | Xamarin <small class="text-secondary">[see (4)]</small>
+| iOS      | Mac computer, Xamarin <small class="text-secondary">[see (4)]</small>
 
-(3) Xamarin is included with Visual Studio installations. For instructions about how to install Xamarin with Visual Studio, see [this MSDN page](https://docs.microsoft.com/en-us/visualstudio/cross-platform/setup-and-install).
+(4) Xamarin is included with Visual Studio installations. For instructions about how to install Xamarin with Visual Studio, see [this MSDN page](https://docs.microsoft.com/en-us/visualstudio/cross-platform/setup-and-install).
 
 ## Running Stride Games
 

--- a/en/manual/troubleshooting/stride-doesnt-run.md
+++ b/en/manual/troubleshooting/stride-doesnt-run.md
@@ -34,6 +34,9 @@ To check if this is installed, follow the instructions on [this page](https://le
 
 If it's not installed, you can download it from the [Microsoft Download Center](https://dotnet.microsoft.com/en-us/download/dotnet-framework).
 
+> [!Note]
+> If you have .NET 4.8 installed, you don't need to install .NET 4.7.2. Each 4.x version is cumulative.
+
 ### Visual Studio 2022 (optional)
 
 If you have Visual Studio 2022 (or later) installed, you need to have the following workloads and/or components installed:

--- a/en/manual/troubleshooting/stride-doesnt-run.md
+++ b/en/manual/troubleshooting/stride-doesnt-run.md
@@ -34,16 +34,13 @@ To check if this is installed, follow the instructions on [this page](https://le
 
 If it's not installed, you can download it from the [Microsoft Download Center](https://dotnet.microsoft.com/en-us/download/dotnet-framework).
 
-> [!Note]
-> If you have .NET 4.8 installed, you don't need to install .NET 4.7.2. Each 4.x version is cumulative.
-
 ### Visual Studio 2022 (optional)
 
 If you have Visual Studio 2022 (or later) installed, you need to have the following workloads and/or components installed:
 * **.NET desktop development** with **Development tools for .NET** optional component enabled.
 
 > [!Note]
-> Earlier versions might work with older version of Stride. However, for Stride 4.2 and later you need to have .NET 8 support.
+> Earlier versions might work with older version of Stride. However, for Stride 4.2 and later you only need to have .NET 8 SDK installed.
 
 ### Build Tools for Visual Studio 2022 (optional)
 

--- a/jp/manual/files-and-folders/distribute-a-game.md
+++ b/jp/manual/files-and-folders/distribute-a-game.md
@@ -57,7 +57,7 @@
 
 Stride で作成されたゲームを Windows で実行するには、次のものが必要です。
 
-* .NET 4.6.1
+* .NET 8 SDK
 
 * DirectX11 (Windows 10 以降に含まれます)、OpenGL、または Vulkan
 

--- a/jp/manual/requirements/index.md
+++ b/jp/manual/requirements/index.md
@@ -36,6 +36,6 @@ Stride がサポートするプラットフォームについては、「[プラ
 
 Stride で作成したゲームを実行するには、次のものが必要です。
 
-- .NET 4.6.1
+- .NET 8 SDK
 - DirectX11 (Windows 10 以降に含まれます)、OpenGL、または Vulkan
 - Visual C++ 2015 ランタイム (Visual Studio でのプロジェクトのプロパティの設定に応じて、x86 および x64 のどちらか一方または両方)


### PR DESCRIPTION
I didn't want to fragment my work into several smaller PRs, as the changes are small.
Here list a list of changes I made:
- Improved doc building - it takes too long to build pdf files, so waiting a few minutes to see changes can be frustrating. I've added an additional parameter that disables pdf gen. step.
- The documentation mentions the .NET FW but this is incorrect because now the entire engine* is based on NET 8 SDK.
- I added another requirement for Linux developers, you must install freeimage to properly compile resources / run games with sprites on Linux. Also, I moved the NET 8 requirement from the Linux requirements page to the general requirements page
- The description of Visual Studio's Stride plugin may be misinterpreted - it may suggest that it is necessary to work with C# syntax correctly, but AFAIR it is necessary to support shader syntax