### PR TITLE
fix: Table layout

### DIFF
--- a/en/manual/graphics/textures/skyboxes-and-backgrounds.md
+++ b/en/manual/graphics/textures/skyboxes-and-backgrounds.md
@@ -54,6 +54,7 @@ Instead of using a cubemap, you can use a **360° panoramic texture** as a 3D ba
 | 360° panorama  | Appearance in game
 |----------------|-------------
 | ![Panorama texture](media/MyPanorama.jpg)  | ![Panorama in game](media/panorama-in-game.jpg)
+
 *Image courtesy of [Texturify](http://texturify.com)*
 
 >[!Note]

--- a/jp/manual/graphics/textures/skyboxes-and-backgrounds.md
+++ b/jp/manual/graphics/textures/skyboxes-and-backgrounds.md
@@ -124,6 +124,7 @@ Instead of using a cubemap, you can use a **360° panoramic texture** as a 3D ba
 | 360° パノラマ   | ゲームでの見た目
 |----------------|-------------
 | ![Panorama texture](media/MyPanorama.jpg)  | ![Panorama in game](media/panorama-in-game.jpg)
+
 *画像提供： [Texturify](http://texturify.com)*
 
 <!--


### PR DESCRIPTION
[Before](https://doc.stride3d.net/4.2/en/manual/graphics/textures/skyboxes-and-backgrounds.html)/After
<img width="905" alt="screenshot" src="https://github.com/user-attachments/assets/14b3187a-59c2-4845-b86a-63b492e7475f">

I know the Japanese manual hasn’t been maintained. This is a layout error, so I fixed it.