### PR TITLE
fix: Fixes #348

### DIFF
--- a/en/docfx.json
+++ b/en/docfx.json
@@ -66,12 +66,13 @@
     },
     "fileMetadata": {
       "_appTitle": {
-        "tutorials/**/*.md": "Stride Tutorials",
-        "manual/**/*.md": "Stride Manual",
-        "ReleaseNotes/**/*.md": "Stride Release notes",
+        "tutorials/**/*.md": "Stride tutorials",
+        "manual/**/*.md": "Stride manual",
+        "ReleaseNotes/**/*.md": "Stride release notes",
         "api/**/*.md": "Stride API",
-        "diagnostics/**/*.md": "Stride Diagnostics",
-        "contributors/**/*.md": "Stride Contributors",
+        "api/**/*.yml": "Stride API",
+        "diagnostics/**/*.md": "Stride diagnostics",
+        "contributors/**/*.md": "Stride contributors",
         "community-resources/**/*.md": "Stride Community resources"
       }
     },


### PR DESCRIPTION
#### PR Classification
Metadata update for documentation files.

#### PR Summary
Updated `_appTitle` metadata for various documentation file patterns to use consistent lowercase titles and changed the file pattern for API documentation.
- Updated titles to lowercase for `tutorials/**/*.md`, `manual/**/*.md`, `ReleaseNotes/**/*.md`, `diagnostics/**/*.md`, and `contributors/**/*.md`.
- Added file pattern for `api` as `api/**/*.yml`.
