### PR TITLE
Updated .NET publishing methods

### DIFF
--- a/en/manual/files-and-folders/distribute-a-game.md
+++ b/en/manual/files-and-folders/distribute-a-game.md
@@ -36,11 +36,11 @@ When you're ready to publish your game, create a release build from Visual Studi
 
     ![Publish Self Contained](media\publish-self-contained.png)
 
-    >[!Note]
+    > [!Note]
     >
-    >You can only build for platforms you've added to your Stride project. For instructions about how to do this, see [Add or remove a platform](../platforms/add-or-remove-a-platform.md).
+    > You can only build for platforms you've added to your Stride project. For instructions about how to do this, see [Add or remove a platform](../platforms/add-or-remove-a-platform.md).
     >
-    >To build for Android or iOS, you need Xamarin, which is included with Visual Studio licenses. For instructions about how to install Xamarin with Visual Studio 2017, see [this MSDN page](https://docs.microsoft.com/en-us/visualstudio/cross-platform/setup-and-install).
+    > To build for Android or iOS, you need Xamarin, which is included with Visual Studio licenses. For instructions about how to install Xamarin with Visual Studio 2017, see [this MSDN page](https://docs.microsoft.com/en-us/visualstudio/cross-platform/setup-and-install).
 
 10. Under **Build**, select **Publish Selection** and click the **Publish** button.
 
@@ -96,7 +96,7 @@ After you create a release build, how you distribute it is up to you.
 
 To run games made with Stride on Windows, users need:
 
-* .NET 8 Runtimes (Unless you published with **self-contained**)
+* .NET 8 Runtime (Unless you published with **self-contained**)
 
 * DirectX11 (included with Windows 10 and later), OpenGL, or Vulkan
 

--- a/en/manual/files-and-folders/distribute-a-game.md
+++ b/en/manual/files-and-folders/distribute-a-game.md
@@ -14,13 +14,27 @@ When you're ready to publish your game, create a release build from Visual Studi
 
     Your project opens in Visual Studio.
 
-4. In Visual Studio, from the **Solution Configurations** drop-down menu, select **Release**.
+4. In Visual Studio, from the **Solution Explorer** right click your Windows project and select **Publish**
 
-    ![Select release](media/select-release.png)
+    ![Select Publish](media\publish-project-dropdown.png)
 
-5. From the **Solution platforms** drop-down menu, select the platform you want to create a build for.
+5. Select the **Target** **Folder** in the publish window.
 
-    ![Select platform](media/select-platform.png)
+6. Select the **Specified target** **Folder** again.
+
+7. Confirm the output folder and Click **Finish**.
+
+8. You should now see the **Publish** view where you can manage the project export settings.
+
+    ![Publish View](media\publish-view.png)
+
+9. Finally you can click publish and see your project in the output folder you selected at **step 6**
+
+    Optionally you can also include the .NET runtime in your exported game to reduce a dependancy on the user.
+
+    Select **Show all settings** -> **Deployment mode** -> **Self-contained** -> **Save**
+
+    ![Publish Self Contained](media\publish-self-contained.png)
 
     >[!Note]
     >
@@ -28,22 +42,39 @@ When you're ready to publish your game, create a release build from Visual Studi
     >
     >To build for Android or iOS, you need Xamarin, which is included with Visual Studio licenses. For instructions about how to install Xamarin with Visual Studio 2017, see [this MSDN page](https://docs.microsoft.com/en-us/visualstudio/cross-platform/setup-and-install).
 
-6. Under **Build**, select **Build solution**.
+10. Under **Build**, select **Publish Selection** and click the **Publish** button.
 
-    ![Build solution](media/build-solution.png)
+    ![Publish Solution](media/publish-project.png)
 
-    Visual Studio creates a release build in your project bin folder (eg *MyGame/Bin/MyPlatform/Release*).
+    Visual Studio creates a release build in your selected output folder.
 
 > [!Tip]
 > You might want to rename the **Release** folder to something more descriptive (such as the title of your game).
 
 ### To build using terminal instead of Visual Studio
 
- 1. You would need to install Visual Studio to get **Developer Command Prompt for Visual Studio (Version)**
- 2. In Developer Command Prompt for Visual Studio
- 3. ```console
-    C:\User> msbuild PathToSln\NameOfProject.sln /p:Configuration=Release /p:OutputPath=YourPreferredPath
-    ```
+ 1. Ensure the relevant .NET SDK is installed (Stride 4.2 is on .NET 8)
+ 2. open the folder of your project where the *.Windows.csproj file sits.
+
+    ![Project Folder](media/project-folder.png)
+
+ 3. Type `cmd` in the search bar to open the folder easily in terminal.
+    
+    ![Open terminal](media/open-terminal.png)
+
+ 4. finally publish with the command 
+ 
+ ```
+ dotnet publish
+ ```
+
+ or the below to include the .NET runtime with your game
+
+ ```
+ dotnet publish -r win-x64 --self-contained true --framework net8.0-windows
+ ```
+ 
+ You can also append `--output <YOUR_EXPORT_FOLDER>` to specify where to export to.
 
 ## 2. Delete unnecessary files
 
@@ -65,7 +96,7 @@ After you create a release build, how you distribute it is up to you.
 
 To run games made with Stride on Windows, users need:
 
-* .NET 8 SDK
+* .NET 8 SDK (Unless you published with **self-contained**)
 
 * DirectX11 (included with Windows 10 and later), OpenGL, or Vulkan
 
@@ -76,3 +107,5 @@ To run games made with Stride on Windows, users need:
 * [Add or remove a platform](../platforms/add-or-remove-a-platform.md)
 * [Version control](version-control.md)
 * [Project structure](project-structure.md)
+
+* [Microsoft documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish)

--- a/en/manual/files-and-folders/distribute-a-game.md
+++ b/en/manual/files-and-folders/distribute-a-game.md
@@ -96,7 +96,7 @@ After you create a release build, how you distribute it is up to you.
 
 To run games made with Stride on Windows, users need:
 
-* .NET 8 SDK (Unless you published with **self-contained**)
+* .NET 8 Runtimes (Unless you published with **self-contained**)
 
 * DirectX11 (included with Windows 10 and later), OpenGL, or Vulkan
 

--- a/en/manual/files-and-folders/media/open-terminal.png
+++ b/en/manual/files-and-folders/media/open-terminal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f158992cde6c16fb30b63c1da1e92eba78366a668c2efe6c088ae51c84a2c69e
+size 33230

--- a/en/manual/files-and-folders/media/project-folder.png
+++ b/en/manual/files-and-folders/media/project-folder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce8e4c330378468774745bfd56ca93f7048bef01484b03784650f023ac3c08d
+size 40745

--- a/en/manual/files-and-folders/media/publish-project-dropdown.png
+++ b/en/manual/files-and-folders/media/publish-project-dropdown.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:135be0d052d1f6c9a904c67baf7c994286e99eb25f306d1f4f9ec2724d90c812
+size 22583

--- a/en/manual/files-and-folders/media/publish-project.png
+++ b/en/manual/files-and-folders/media/publish-project.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de68e02cb3e24c4d9d701552ef55d5dd01d7af0faa2f7e151f185803e1cb74a5
+size 33082

--- a/en/manual/files-and-folders/media/publish-self-contained.png
+++ b/en/manual/files-and-folders/media/publish-self-contained.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d9a4dfd41bb58ac32605ca66d6f6179bc21e7b6422a59db8128530a85c2eda6
+size 35056

--- a/en/manual/files-and-folders/media/publish-view.png
+++ b/en/manual/files-and-folders/media/publish-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b5f3440cfcfd29c9bbb53669fcd72ab382693f23ac901ccd5b1314bdf53ed0
+size 18383


### PR DESCRIPTION
This updates the game release page to the newer .NET ways. 

- removes references to msbuild
- uses VS2022 publish page
- better less cumbersome terminal usage