### PR TITLE
Deploy latest documentation updates to staging

### DIFF
--- a/.github/workflows/stride-docs-release-azure.yml
+++ b/.github/workflows/stride-docs-release-azure.yml
@@ -3,6 +3,9 @@
 
 name: Build Stride Docs for Azure Web App Release 🚀
 
+permissions:
+  contents: write  # required to create releases/tags
+
 env:
   COMMON_SETTINGS_PATH: en/docfx.json
   VERSION: "2.0.0.${{ github.run_number }}"

--- a/en/ReleaseNotes/ReleaseNotes.md
+++ b/en/ReleaseNotes/ReleaseNotes.md
@@ -8,8 +8,9 @@ Read the full blog post here: [Announcing Stride 4.2](https://www.stride3d.net/b
 
 A massive thank you to the open-source Stride community for your dedicated contributions. This release saw over 75 contributions from more than 22 amazing contributors, each playing a crucial role in making Stride 4.2 a reality.
 
-## Minor releases since the last major release
+## Other releases since the last major release
 
+- [4.2.1.2442](https://github.com/stride3d/stride/releases/tag/releases%2F4.2.1.2442): August 2025
 - [4.2.0.2381](https://github.com/stride3d/stride/releases/tag/releases%2F4.2.0.2381): March 2025
 - [4.2.0.2374](https://github.com/stride3d/stride/releases/tag/releases%2F4.2.0.2374): February 2025
 - [4.2.0.2293](https://github.com/stride3d/stride/releases/tag/releases%2F4.2.0.2293): January 2025

--- a/en/contributors/engine/building-source-windows-other-ide.md
+++ b/en/contributors/engine/building-source-windows-other-ide.md
@@ -1,16 +1,33 @@
 # Build Stride without Visual Studio
 
-1. Install [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with the same prerequisites listed [here](building-source-windows.md)
-2. Add MSBuild's directory to your system's *PATH* (ex: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin`)
-3. Open a command prompt, point it to a directory and clone Stride to it: `git lfs clone https://github.com/stride3d/stride.git`
-4. Navigate to `/Build` with the command prompt, input `msbuild /t:Restore Stride.sln` then `compile.bat`
+1. **Install** [Visual Studio Build Tools](https://aka.ms/vs/17/release/vs_BuildTools.exe) with the same prerequisites listed above.
+2. **Add MSBuild to your system's PATH:**
+   - Add MSBuild's directory to your `PATH` environment variable (e.g., `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin`).
+3. **Clone the repository:**
+   ```bash
+   git lfs clone https://github.com/stride3d/stride.git
+
+   ```
+4. **Build using the command line:**
+   - Navigate to the `/build` directory in the command prompt and run:
+   ```bash
+   msbuild /t:Restore Stride.sln
+
+   ```
+   - Then run:
+   ```bash
+   compile.bat
+
+   ```
 
 ## Build Stride with Rider
-With Rider 2024.1 and after [commit 0e053a3](https://github.com/stride3d/stride/commit/0e053a3b8873f49e9e0e5450a3dfad368a6ed042) Stride can now be built hassle free from Rider, you just have to make sure that `Use ReSharper Build` is enabled in your settings.
+
+With Rider 2025.2 and after [commit 0e053a3](https://github.com/stride3d/stride/commit/0e053a3b8873f49e9e0e5450a3dfad368a6ed042) Stride can now be built hassle free from Rider, you just have to make sure that `Use ReSharper Build` is enabled in your settings.
 
 ![image](https://github.com/stride3d/stride-docs/assets/5742236/9ce4e30d-0d6b-4a56-844d-313a826742bf)
 
 ### Hot Reload
+
 To hot reload your changes, you can either pause and continue the program or click the hot reload button at the top of the text editor when it appears.
 
 ![image](https://user-images.githubusercontent.com/5742236/147461531-05af59f7-fedf-44a2-b4ee-d1aa25502210.png)

--- a/en/contributors/engine/building-source-windows-visual-studio.md
+++ b/en/contributors/engine/building-source-windows-visual-studio.md
@@ -1,0 +1,35 @@
+# Build Stride with Visual Studio 2022
+
+Here are the steps to build Stride with Visual Studio. If you do not have or want to use Visual Studio, see [building with other IDEs](building-source-windows-other-ide.md).
+
+1. **Clone the repository** using a Git UI client or from the command line:
+   ```bash
+   git lfs clone https://github.com/stride3d/stride.git
+   ```
+2. **Open the solution:**
+   - Open `<StrideDir>\build\Stride.sln` with Visual Studio 2022. 
+   - Build the `Stride.GameStudio` project in the `60-Editor` solution folder (it should be the default startup project) or run it directly from Visual Studio's toolbar.
+   - _Optionally_, open and build `Stride.Android.sln`, `Stride.iOS.sln`, etc.
+
+> [!WARNING]
+> **Do NOT use GitHub -> Code -> Download ZIP** option, as this won't include the LFS files.
+
+## If building failed
+
+* Some errors for test projects are normal, GameStudio will start anyway.
+* The Visual Studio extension might fail to build if you are missing the [Visual Studio SDK](https://learn.microsoft.com/en-us/visualstudio/extensibility/installing-the-visual-studio-sdk?view=vs-2022), but Game Studio will start anyway.
+* If you skipped any of the **Prerequisites** thinking you already have the latest version, please update to the latest to be sure.
+* Visual Studio might have issues building properly if an older version is present alongside 2022. If you want to keep those versions, ensure they are up to date and that you are building Stride using Visual Studio 2022.
+* Your system's `PATH` should not contain older versions of MSBuild (e.g., `...\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin` should be removed).
+* Some changes might require a system reboot. Try that if you haven't yet, for example, if you see these errors:
+  * `Could not find a compatible version of MSBuild.`
+  * `Path to dotnet executable is not set.`
+* Ensure that Git, Git LFS, and Visual Studio can access the internet.
+* Close Visual Studio, clear the NuGet cache (`dotnet nuget locals all --clear`), delete the hidden `.vs` folder inside `\build` and the files inside `bin\packages`, kill any `msbuild` and other Visual Studio processes, then build the whole solution and run GameStudio.
+
+> [!WARNING]
+> Test solutions might fail, but this should not prevent you from building `Stride.GameStudio`.
+
+## Other IDEs
+
+You are not required to use Visual Studio to build the Stride engine with Visual Studio. You can also build entirely from command line or other IDE's such as [Rider or Visual Studio Code](building-source-windows-other-ide.md).

--- a/en/contributors/engine/building-source-windows.md
+++ b/en/contributors/engine/building-source-windows.md
@@ -1,15 +1,16 @@
-# Building the source to Stride engine
+# Building source on Windows
 
 ## Prerequisites
 
 1. **Latest [Git](https://git-scm.com/downloads)** with **Large File Support** selected during setup. For convenience, you might also use a Git UI client like [GitExtensions](https://gitextensions.github.io/).
 2. **[.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)**
    - Run `dotnet --info` in a console or PowerShell window to see which versions you have installed.
-3. **[Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)** (the Community edition is free) with the following workloads:
-   - **.NET desktop development** with **.NET Framework 4.7.2 targeting pack** (should be enabled by default)
+3. **[Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)** (the Community edition is free), with the following workloads. Follow this link if you would rather use [a different IDE or the command line](#build-stride-without-visual-studio).
+   - **.NET desktop development** with **.NET Framework 4.7.2 targeting pack** *(should be enabled by default)*
    - **Desktop development with C++** with:
-     - **Windows 11 SDK (10.0.22621.0)** or a later version (should be enabled by default)
-     - **MSVC v143 - VS2022 C++ x64/x86 build tools (Latest)** (should be enabled by default)
+     - **Windows 11 SDK (10.0.22621.0)** or a later version *(should be enabled by default)*
+     - **MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)** *(should be enabled by default)*
+     - **MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)** *(not enabled by default, click Individual components tab to select or search)*
      - **C++/CLI support for v143 build tools (Latest)** *(not enabled by default)*
    - *Optional* (to target iOS/Android): **.NET Multi-platform App UI development** and the **Android SDK setup** individual component (enabled by default). Then, in Visual Studio, go to `Tools > Android > Android SDK Manager` and install **NDK** (version 20.1+) from the `Tools` tab.
    - *Optional* (to build the VSIX package): **Visual Studio extension development**
@@ -20,32 +21,7 @@
 > [!WARNING]
 > If this is your first time installing the .NET SDK, you might need to restart your system after the installation so that the system can recognize the new environment variables.
 
-## Build Stride with Visual Studio 2022
-Here are the steps to build Stride with Visual Studio. If you do not have or want to use Visual Studio, see [building with other IDEs](building-source-windows-other-ide.md)
+## Build Stride
 
-1. **Clone the repository** using a Git UI client or from the command line:
-   ```bash
-   git lfs clone https://github.com/stride3d/stride.git
-   ```
-2. **Open the solution:**
-   - Open `<StrideDir>\build\Stride.sln` with Visual Studio 2022. 
-   - Build the `Stride.GameStudio` project in the `60-Editor` solution folder (it should be the default startup project) or run it directly from Visual Studio's toolbar.
-   - _Optionally_, open and build `Stride.Android.sln`, `Stride.iOS.sln`, etc.
-
-> [!WARNING]
-> **Do NOT use GitHub -> Code -> Download ZIP** option, as this won't include the LFS files.
-
-### If building failed
-* If you skipped one of the `Prerequisites` thinking that you already have the latest version, update to the latest anyway just to be sure.
-* Visual Studio might have issues properly building if an anterior version is present alongside 2022. If you want to keep those version make sure that they are up to date and that you are building Stride through VS 2022.
-* Your system's *PATH* should not contain older versions of MSBuild (ex: `...\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin` should be removed)
-* Some changes might require a system reboot. Try that if you haven't yet, for example, if you see these errors:
-  * `Could not find a compatible version of MSBuild.`
-  * `Path to dotnet executable is not set.`
-* Make sure that Git, Git LFS and Visual Studio can access the internet.
-* Close VS, clear the nuget cache (in your cmd `dotnet nuget locals all --clear`), delete the hidden `.vs` folder inside `\build` and the files inside `bin\packages`, kill any msbuild and other vs processes, build the whole solution then build and run GameStudio.
-
-Do note that test solutions might fail but it should not prevent you from building `Stride.GameStudio`.
-
-## Other IDEs
-You are not required to use Visual Studio to build the Stride engine with Visual Studio. You can also build entirely from command line or other IDE's such as [Rider or Visual Studio Code](building-source-windows-other-ide.md).
+- [Visual Studio 2022 instructions](building-source-windows-visual-studio.md)
+- [Rider or Visual Studio Code instructions](building-source-windows-other-ide.md)

--- a/en/contributors/major-release-workflow.md
+++ b/en/contributors/major-release-workflow.md
@@ -8,5 +8,6 @@
    - In the "Building from Source - Prerequisites" section, update the .NET SDK version references
 1. Update the Discord #welcome channel
    - Refresh the SDK version references. If you're unable to edit the message directly, copy its content, delete the original message, and then create a new one with the updated information
+1. Update Stride development NuGet packages version in all samples in `https://github.com/stride3d/stride/tree/master/samples`
 1. Follow the steps outlined in the [Docs Major Release Workflow](documentation/major-release-workflow.md)
 1. Proceed with the steps in the [Website Major Release Workflow](website/major-release-workflow.md)

--- a/en/contributors/toc.yml
+++ b/en/contributors/toc.yml
@@ -30,6 +30,11 @@ items:
     href: engine/bug-bounties.md
   - name: Building source on Windows
     href: engine/building-source-windows.md
+    items:
+    - name: Visual Studio
+      href: engine/building-source-windows-visual-studio.md
+    - name: Rider or Other IDEs
+      href: engine/building-source-windows-other-ide.md
   - name: Localization
     href: engine/localization.md
   - name: Hot reloading editor shaders

--- a/en/manual/toc.yml
+++ b/en/manual/toc.yml
@@ -628,5 +628,9 @@ items:
         href: troubleshooting/lights-dont-cast-shadows.md
       - name: Full call stack not available
         href: troubleshooting/full-call-stack-not-available.md
-      - name: "Error: A SceneCameraRenderer in use has no camera assigned to its [Slot]. Make sure a camera is enabled and assigned to the [Slot]"
+      - name: SceneCameraRenderer error
         href: troubleshooting/error-a-scenecamerarenderer-in-use-has-no-camera-set.md
+      - name: Unable to resolve Stride.GameStudio
+        href: troubleshooting/unable-to-resolve-stride-game-studio.md
+      - name: The Launcher is showing only 3.x version
+        href: troubleshooting/unable-to-resolve-stride-game-studio.md

--- a/en/manual/troubleshooting/index.md
+++ b/en/manual/troubleshooting/index.md
@@ -12,4 +12,6 @@ These pages describe how to fix problems with Stride.
 * [Default value changes ignored at runtime](default-value-changes-ignored-at-runtime.md)
 * [Lights don't cast shadows](lights-dont-cast-shadows.md)
 * [Full call stack not available](full-call-stack-not-available.md)
-* [Error: "A SceneCameraRenderer in use has no camera assigned to its [Slot]. Make sure a camera is enabled and assigned to the [Slot]"](error-a-scenecamerarenderer-in-use-has-no-camera-set.md)
+* [SceneCameraRenderer error](error-a-scenecamerarenderer-in-use-has-no-camera-set.md)
+* [Unable to resolve Stride.GameStudio](unable-to-resolve-stride-game-studio.md)
+* [The Launcher is showing only 3.x version](unable-to-resolve-stride-game-studio.md)

--- a/en/manual/troubleshooting/unable-to-resolve-stride-game-studio.md
+++ b/en/manual/troubleshooting/unable-to-resolve-stride-game-studio.md
@@ -1,0 +1,56 @@
+# NuGet.Config misconfiguration
+
+## Unable to resolve Stride.GameStudio
+
+If you encounter the error:
+
+```
+Error: Unable to resolve 'Stride.GameStudio (>= 4.2.0.2381)' for 'net8.0-windows7.0'.
+
+Exception
+
+Could not restore package Stride.GameStudio
+at Stride.Core.Packages.NugetStore.InstallPackage(String packageId, PackageVersion version, IEnumerable`1 targetFrameworks, ProgressReport progress)
+at Stride.LauncherApp.ViewModels.PackageVersionViewModel.<>c__DisplayClass55_0.<b__0>d.MoveNext()
+```
+
+This usually means your NuGet package sources are misconfigured.
+
+## How to fix
+
+1. Locate your NuGet configuration file:
+   - `C:\Users\YourUserName\AppData\Roaming\NuGet\NuGet.Config`
+2. Make a backup of the file before editing.
+3. Open the file and ensure it contains the following lines:
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        <add key="Stride Dev" value="C:\Users\YourUserName\AppData\Local\Stride\NugetDev" />
+      </packageSources>
+    </configuration>
+    ```
+4. Save the file and try restoring packages again.
+
+## The launcher only finds 3.x versions, not 4.x
+
+If the install program (Launcher) only shows Stride 3.x versions and not 4.x, your `NuGet.Config` file is likely missing the `nuget.org` package source.
+
+### How to fix
+
+1. Open your NuGet configuration file:
+   - `C:\Users\YourUserName\AppData\Roaming\NuGet\NuGet.Config`
+2. Make a backup before editing.
+3. Ensure your `NuGet.Config` contains at least the following:
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+      </packageSources>
+    </configuration>
+    ```
+4. Save the file and restart the Launcher.
+
+You should now see the latest Stride 4.x versions available for installation.


### PR DESCRIPTION
* chore: August release link added

* chore: Visual studio instructions separated to a new file

* feat: New error message added

* fix: Grammar corrected

* feat: Docs improvements

* docs: Content improvements

* ci: stride-docs-release-azure.yml - Update permissions

- Added a new `permissions` section with `contents` set to `write`, required for creating releases and tags.