### PR TITLE
feat: Adjusted formatting and style

### DIFF
--- a/en/manual/files-and-folders/building-the-game/native-aot.md
+++ b/en/manual/files-and-folders/building-the-game/native-aot.md
@@ -6,12 +6,12 @@ C# and other languages from the .NET ecosystem are compiled into **Common Interm
 
 This approach has it's benefits and drawbacks:
 
-* 🟩 Your code can run on any platform supported by the **.NET Runtime**
-* 🟩 Some high-level language features require it to work (e.g. reflections)
-* 🟩 Compiled projects take up less disk space
-* 🟥 Some platforms do not support it (mainly iOS and consoles)
-* 🟥 Creates additional overhead, which can slightly decrease performance in some cases
-* 🟥 Requires a user to install additional software (unless the app is made to be [self contained](setup.md#self-contained))
+* <span class="positive"/> Your code can run on any platform supported by the **.NET Runtime**
+* <span class="positive"/> Some high-level language features require it to work (e.g. reflections)
+* <span class="positive"/> Compiled projects take up less disk space
+* <span class="negative"/> Some platforms do not support it (mainly iOS and consoles)
+* <span class="negative"/> Creates additional overhead, which can slightly decrease performance in some cases
+* <span class="negative"/> Requires a user to install additional software (unless the app is made to be [self contained](setup.md#self-contained))
 
 An alternative to this is to use **Native Ahead-Of-Time** (AOT) compilation to skip the CIL entirely, creating a native program. Doing this can decrease startup time and in some cases slightly improve performance, but comes at the cost of all previously listed benefits of a standard JIT compiled .NET application.
 

--- a/en/manual/files-and-folders/building-the-game/setup.md
+++ b/en/manual/files-and-folders/building-the-game/setup.md
@@ -89,9 +89,10 @@ Due to how .NET applications generally work, Stride games require the runtime in
 > .NET applications are fairly common, especially on **Windows**, so it's very likely that a user already has it installed.
 
 There are benefits and drawbacks to making a game **self contained**:
-* 🟩 **Benefits**: the game will work even if a user doesn't have the runtime installed.
-* 🟥 **Drawbacks**: the game's size will be larger.
 
+* <span class="positive"/> **Benefits:** the game will work even if a user doesn't have the runtime installed.
+* <span class="negative"/> **Drawbacks:** the game's size will be larger.
+`
 ### [Visual Studio](#tab/visual-studio)
 
 In the profile settings, change the **Deployment mode** option to **Self-contained**.

--- a/en/manual/files-and-folders/building-the-game/setup.md
+++ b/en/manual/files-and-folders/building-the-game/setup.md
@@ -92,7 +92,7 @@ There are benefits and drawbacks to making a game **self contained**:
 
 * <span class="positive"/> **Benefits:** the game will work even if a user doesn't have the runtime installed.
 * <span class="negative"/> **Drawbacks:** the game's size will be larger.
-`
+
 ### [Visual Studio](#tab/visual-studio)
 
 In the profile settings, change the **Deployment mode** option to **Self-contained**.

--- a/en/manual/install-and-update/install-stride.md
+++ b/en/manual/install-and-update/install-stride.md
@@ -45,8 +45,8 @@ Changing the installation location is possible, but explaining this is outside o
 
 Stride has an optional extension that's available for some IDEs.
 
-- **🟩 What it does**: provides shader syntax highlighting useful utilities related to the engine.
-- **🟥 What it doesn't do**: provide C# syntax highlighting for Stride (that works without the extension).
+* <span class="negative"/> **What it does:** provides shader syntax highlighting useful utilities related to the engine.
+* <span class="positive"/> **What it doesn't do:** provide C# syntax highlighting for Stride (that works without the extension).
 
 The extension can be installed for Visual Studio via the launcher, by navigating to the **Visual Studio extension** section. For other IDEs, visit the [Stride Extension page](../get-started/visual-studio-extension.md).
 

--- a/en/template/public/main.css
+++ b/en/template/public/main.css
@@ -72,24 +72,24 @@ blockquote {
 }
 
 /* Adjust content font-size and margins */
-.content {
-    article > * {
+.content > article {
+    > * {
         margin-left: 0.4rem;
     }
 
-    h1, h2, p:has(span.badge) {
+    > h1, > h2, > p:has(span.badge) {
         margin-left: 0rem;
     }
 
-    h1 {
+    > h1 {
         font-size: 2.7rem;
     }
 
-    h2 {
+    > h2 {
         font-size: 2.2rem;
     }
 
-    h3 {
+    > h3 {
         font-size: 1.7rem;
     }
 }

--- a/en/template/public/main.css
+++ b/en/template/public/main.css
@@ -98,10 +98,10 @@ blockquote {
 li:has(.positive)::marker {
     content: '＋ ';
     font-weight: bold;
-    color: green;
+    color: var(--bs-success);
 }
 
 li:has(.negative)::marker {
     content: '－ ';
-    color: red;
+    color: var(--bs-danger);
 }

--- a/en/template/public/main.css
+++ b/en/template/public/main.css
@@ -51,6 +51,7 @@ footer .link-danger {
     color: var(--stride-red-web);
 }
 
+/* Blockquote and alert style */
 blockquote {
     border-width: 0 0 0 4px;
     border-color: var(--stride-red-web);
@@ -61,4 +62,46 @@ blockquote {
 [data-bs-theme=dark] blockquote {
     border-color: var(--stride-red-web);
     background: #33383c;
+}
+
+.alert.TIP {
+    --bs-alert-color: var(--bs-success-text-emphasis);
+    --bs-alert-bg: var(--bs-success-bg-subtle);
+    --bs-alert-border-color: var(--bs-success-border-subtle);
+    --bs-alert-link-color: var(--bs-success-text-emphasis);
+}
+
+/* Adjust content font-size and margins */
+.content {
+    article > * {
+        margin-left: 0.4rem;
+    }
+
+    h1, h2, p:has(span.badge) {
+        margin-left: 0rem;
+    }
+
+    h1 {
+        font-size: 2.7rem;
+    }
+
+    h2 {
+        font-size: 2.2rem;
+    }
+
+    h3 {
+        font-size: 1.7rem;
+    }
+}
+
+/* +/- bullet points */
+li:has(.positive)::marker {
+    content: '＋ ';
+    font-weight: bold;
+    color: green;
+}
+
+li:has(.negative)::marker {
+    content: '－ ';
+    color: red;
 }


### PR DESCRIPTION
I made slight adjustments to font size and margins to make it easier to differentiate h2 from h3.

Notice the difference between first header and second.
| Before | After |
| :-: | :-: |
| <img width="1283" height="756" alt="image" src="https://github.com/user-attachments/assets/322640d6-e7ab-475f-adb3-5010bcd61c1a" /> | <img width="1280" height="771" alt="image" src="https://github.com/user-attachments/assets/e309036a-8586-4f5f-b161-cb7c5cc24842" /> |

Bullet points can now also be `-` or `+`, which is great for lists showcasing benefits and drawbacks.

| Before | After |
| :-: | :-: |
| <img width="1089" height="292" alt="image" src="https://github.com/user-attachments/assets/e164fd6e-4073-4f5c-b14e-0d45e7a9517f" /> | <img width="1051" height="296" alt="image" src="https://github.com/user-attachments/assets/ef2c62fe-8730-4459-9d4f-0a3f12d1218b" /> |

Finally, tips are now green, so that hopefully the color will make your brain subconsciously think "oh neat, I can learn something extra by paying attention to this" instead of "another note, ignoring it should be fine".