### PR TITLE
feat: Asset packs section for `Create a project > Stride CLI`

### DIFF
--- a/en/includes/cli-new-project-parameters.md
+++ b/en/includes/cli-new-project-parameters.md
@@ -5,7 +5,7 @@ All Stride templates can take additional parameters to change how they are creat
 | `-n` | text | Name of the project. |
 | `--platform` | `host` (the current os), `window`, `linux`, `macos`, `android`, `ios` | Platform(s) the project should target, separated by the `|` character. |
 | `--HDR` | `true`, `false` | Determines if the project uses HDR (required graphics profile >= 10.0). |
-| `--graphics-profile` | `9.0`, `10.0`, `11.0` | The graphics profile to use. This can be changed later. |
+| `--graphics-profile` | `9.0`, `10.0`, `11.0`, ... | The graphics profile to use. This can be changed later. |
 | `--orientation` | `Default`, `LandscapeLeft`, `LandscapeRight`, `Portrait` | The game's orientation on mobile devices. This can be changed later. |
 
 For a list of all available parameters in a template, use the `--help` flag.

--- a/en/manual/get-started/create-a-project.md
+++ b/en/manual/get-started/create-a-project.md
@@ -85,6 +85,30 @@ The Stride CLI tool provides a way of creating new projects without the need for
 
 [!INCLUDE [cli-new-project-parameters](../../includes/cli-new-project-parameters.md)]
 
+### Asset packs
+
+Stride provides additional asset packs to help you more easily get started working on a game. These asset packs can be added through the CLI at any point after a project's creation. 
+
+1. Go to your project's main [project package](../files-and-folders/project-packages/index.md) directory (the one that ends with `.Game`).
+
+    ```bash
+    cd ./NameOfGame/NameOfGame.Game
+    ```
+
+2. Find the asset pack you want to use. For a list of all asset packs, use the following command and look for items under `Stride.Templates.AssetPacks`.
+
+    ```bash
+    stride new list
+    ```
+
+3. Add the asset pack to your project with the following command:
+
+    ```bash
+    stride new AssetPackIdHere
+    ```
+
+You should now notice new files appear in the `Assets` and `Resources` folders.
+
 ## Create a project with dotnet templates
 
 An alternative way of creating a project from the command line without the need for Stride CLI is to use **dotnet templates**.
@@ -98,6 +122,8 @@ An alternative way of creating a project from the command line without the need 
     dotnet new install Stride.Templates.Games.Starters
     # Install samples (complete games)
     dotnet new install Stride.Templates.Samples
+    # Install asset packs
+    dotnet new install Stride.Templates.AssetPacks
     ```
 
 2. Find the template you want to use. The default project template is named `stride-game`. For a list of all Stride templates, use this command:

--- a/en/manual/get-started/media/create-project-create-new-game.webp
+++ b/en/manual/get-started/media/create-project-create-new-game.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb473e748a0d26fa681fe611b50d2e14831b00042764e819b5b46c145796a0f3
-size 27974
+oid sha256:9f85ec7da0dd3a7a9348de24a766f908aae301c2a169748eccd5492e84f6b01c
+size 46178


### PR DESCRIPTION
* Added a section describing how to use asset packs in a project through the CLI.
* Updated the `New game` dialogue image.
* Added mention of `Stride.Templates.AssetPacks` package in the dotnet templates section.

NOTE: Right now you can't add asset packs to a project through the CLI tool, as the package with the asset packs isn't downloaded when installing Stride.